### PR TITLE
Add experimentalObjectRestSpread for JS style

### DIFF
--- a/javascript/.eslintrc.json
+++ b/javascript/.eslintrc.json
@@ -5,6 +5,7 @@
     "es6": true
   },
   "extends": "eslint:recommended",
+  "parser": "babel-eslint",
   "parserOptions": {
     "ecmaVersion": 6,
     "ecmaFeatures": {


### PR DESCRIPTION
Hound complains about rest/spread, for example: https://github.com/hatchedlabs/grocery/pull/80#discussion_r218895909

Based on:

- https://eslint.org/docs/4.0.0/user-guide/configuring
- https://intercom.help/hound/configuration/eslint

---

Also specifies the parser to try and fix parsing errors for class properties: https://github.com/babel/babel-eslint/issues/312