### PR TITLE
Try forcing verification for project sub-folders

### DIFF
--- a/elixir/.credo.exs
+++ b/elixir/.credo.exs
@@ -21,7 +21,7 @@
         # You can give explicit globs or simply directories.
         # In the latter case `**/*.{ex,exs}` will be used.
         #
-        included: ["lib/", "src/", "test/", "web/", "apps/"],
+        # included: ["lib/", "src/", "test/", "web/", "apps/"],
         excluded: [~r"/_build/", ~r"/deps/", ~r"/node_modules/"]
       },
       #


### PR DESCRIPTION
Allow Credo's generic glob to select Elixir files for verification and only exclude some directories.

The problem is that Hound complains about lines longer than 80 chars although the config should allow 120.