### PR TITLE
Merge grocery repo's eslintrc into hound's eslintrc

### DIFF
--- a/javascript/.eslintrc.json
+++ b/javascript/.eslintrc.json
@@ -1,398 +1,86 @@
 {
   "env": {
-    "amd": true,
-    "browser": true,
     "es6": true,
-    "jest/globals": true
+    "browser": true
   },
-  "parser": "babel-eslint",
-  "parserOptions": {
-    "ecmaVersion": 6,
-    "ecmaFeatures": {
-      "spread": true,
-      "blockBindings": true,
-      "destructuring": true,
-      "templateStrings": true,
-      "jsx": true,
-      "generators": true,
-      "defaultParams": true,
-      "modules": true,
-      "arrowFunctions": true,
-      "forOf": true,
-      "classes": true,
-      "experimentalObjectRestSpread": true
-    },
-    "sourceType": "module"
-  },
-  "plugins": [
-    "flowtype",
-    "jest",
-    "jsx-a11y",
-    "react"
-  ],
   "extends": [
     "eslint:recommended",
-    "plugin:flowtype/recommended",
-    "plugin:import/errors",
-    "plugin:import/warnings",
-    "plugin:jest/recommended",
     "plugin:jsx-a11y/recommended",
-    "plugin:react/all"
+    "plugin:jest/recommended",
+    "standard",
+    "standard-react"
   ],
+  "parser": "babel-eslint",
   "rules": {
-    "comma-dangle": [
-      2,
-      "never"
-    ],
-    "no-cond-assign": 2,
-    "no-console": 1,
-    "no-constant-condition": 2,
-    "no-control-regex": 2,
-    "no-debugger": 2,
-    "no-dupe-args": 2,
-    "no-dupe-keys": 2,
-    "no-duplicate-case": 2,
-    "no-empty": 2,
-    "no-empty-character-class": 2,
-    "no-ex-assign": 2,
-    "no-extra-boolean-cast": 2,
-    "no-extra-parens": 0,
-    "no-extra-semi": 2,
-    "no-func-assign": 2,
-    "no-inner-declarations": [
-      2,
-      "functions"
-    ],
-    "no-invalid-regexp": 2,
-    "no-irregular-whitespace": 2,
-    "no-negated-in-lhs": 2,
-    "no-obj-calls": 2,
-    "no-regex-spaces": 2,
-    "no-sparse-arrays": 2,
-    "no-unexpected-multiline": 2,
-    "no-unreachable": 2,
-    "use-isnan": 2,
-    "valid-jsdoc": 0,
-    "valid-typeof": 2,
-    "accessor-pairs": 2,
-    "block-scoped-var": 0,
-    "complexity": [
-      2,
-      6
-    ],
-    "consistent-return": 0,
-    "curly": 1,
-    "default-case": 0,
-    "dot-location": 0,
-    "dot-notation": 0,
-    "eqeqeq": 2,
-    "guard-for-in": 2,
-    "no-alert": 2,
-    "no-caller": 2,
-    "no-case-declarations": 2,
-    "no-div-regex": 2,
-    "no-else-return": 0,
-    "no-empty-pattern": 2,
-    "no-eq-null": 2,
-    "no-eval": 2,
-    "no-extend-native": 2,
-    "no-extra-bind": 2,
-    "no-fallthrough": 2,
-    "no-floating-decimal": 0,
-    "no-implicit-coercion": 0,
-    "no-implied-eval": 2,
+    "indent": 1,
+    "no-multi-spaces": 1,
+    "jsx-quotes": [1, "prefer-double"],
+    "no-extra-semi": 1,
+    "quotes": [1, "double"],
+    "semi": [1, "always"],
+    "no-console": [2, { "allow": ["warn", "error"] }],
+    "comma-dangle": 1,
+    "block-scoped-var": 1,
+    "complexity": [1, 8],
+    "no-alert": 1,
     "no-invalid-this": 0,
-    "no-iterator": 2,
-    "no-labels": 0,
-    "no-lone-blocks": 2,
-    "no-loop-func": 2,
-    "no-magic-number": 0,
-    "no-multi-spaces": 0,
-    "no-multi-str": 0,
-    "no-native-reassign": 2,
-    "no-new-func": 2,
-    "no-new-wrappers": 2,
-    "no-new": 2,
-    "no-octal-escape": 2,
-    "no-octal": 2,
-    "no-proto": 2,
-    "no-redeclare": 2,
-    "no-return-assign": 2,
-    "no-script-url": 2,
-    "no-self-compare": 2,
-    "no-sequences": 0,
-    "no-throw-literal": 0,
-    "no-unused-expressions": [
-      2,
-      { "allowShortCircuit": true, "allowTernary": true, "allowTaggedTemplates": true }
-    ],
-    "no-useless-call": 2,
-    "no-useless-concat": 2,
-    "no-void": 2,
-    "no-warning-comments": 0,
-    "no-with": 2,
-    "radix": [
-        2,
-        "as-needed"
-    ],
-    "vars-on-top": 0,
-    "wrap-iife": 2,
-    "yoda": 0,
-    "strict": 0,
-    "init-declarations": 0,
-    "no-catch-shadow": 2,
-    "no-delete-var": 2,
-    "no-label-var": 2,
-    "no-shadow-restricted-names": 2,
-    "no-shadow": 0,
-    "no-undef-init": 2,
-    "no-undef": 0,
-    "no-undefined": 0,
+    "no-labels": [1, { "allowLoop": true }],
+    "max-len": [1, 100],
+    "no-negated-condition": 1,
+    "no-nested-ternary": 2,
+    "prefer-const": 2,
+    "space-before-function-paren": 0,
+
+    "no-unused-expressions": [2, { "allowTaggedTemplates": true }],
     "no-unused-vars": [
       2,
       { "vars": "all", "args": "none", "ignoreRestSiblings": true }
     ],
-    "no-use-before-define": 0,
-    "callback-return": 2,
-    "global-require": 2,
-    "handle-callback-err": 2,
-    "no-mixed-requires": 0,
-    "no-new-require": 0,
-    "no-path-concat": 2,
-    "no-process-exit": 2,
-    "no-restricted-modules": 0,
-    "no-sync": 0,
-    "array-bracket-spacing": 0,
-    "block-spacing": 0,
-    "brace-style": 0,
-    "camelcase": 0,
-    "comma-spacing": 0,
-    "comma-style": 0,
-    "computed-property-spacing": 0,
-    "consistent-this": 0,
-    "eol-last": 0,
-    "func-names": 0,
-    "func-style": 0,
-    "id-length": 0,
-    "id-match": 0,
-    "indent": 0,
-    "jsx-quotes": 0,
-    "key-spacing": 0,
-    "linebreak-style": 0,
-    "lines-around-comment": 0,
-    "max-depth": 0,
-    "max-len": [
-      1,
-      120
-    ],
-    "max-nested-callbacks": 0,
-    "max-params": 0,
-    "max-statements": [
-      2,
-      30
-    ],
-    "new-cap": 0,
-    "new-parens": 0,
-    "newline-after-var": 0,
-    "no-array-constructor": 0,
-    "no-bitwise": 0,
-    "no-continue": 0,
-    "no-inline-comments": 0,
-    "no-lonely-if": 0,
-    "no-mixed-spaces-and-tabs": 0,
-    "no-multiple-empty-lines": 0,
-    "no-negated-condition": 0,
-    "no-nested-ternary": 0,
-    "no-new-object": 0,
-    "no-plusplus": 0,
-    "no-restricted-syntax": 0,
-    "no-spaced-func": 0,
-    "no-ternary": 0,
-    "no-trailing-spaces": 0,
-    "no-underscore-dangle": 0,
-    "no-unneeded-ternary": 0,
-    "object-curly-spacing": 0,
-    "one-var": 0,
-    "operator-assignment": 0,
-    "operator-linebreak": 0,
-    "padded-blocks": 0,
-    "quote-props": 0,
-    "quotes": 0,
-    "require-jsdoc": 0,
-    "semi-spacing": 0,
-    "semi": [
-      2,
-      "always"
-    ],
-    "sort-vars": 0,
-    "space-after-keywords": 0,
-    "space-before-blocks": 0,
-    "space-before-function-paren": 0,
-    "space-before-keywords": 0,
-    "space-in-parens": 0,
-    "space-infix-ops": 0,
-    "space-return-throw-case": 0,
-    "space-unary-ops": 0,
-    "spaced-comment": 0,
-    "wrap-regex": 0,
 
-    "arrow-body-style": [
-      2,
-      "as-needed",
-      { "requireReturnForObjectLiteral": false }
-    ],
-    "arrow-parens": [
-      2,
-      "as-needed",
-      { "requireForBlockBody": true }
-    ],
-    "arrow-spacing": [
-      2,
-      { "before": true, "after": true }
-    ],
-    "constructor-super": 2,
-    "generator-star-spacing": [
-      2,
-      { "before": false, "after": true }
-    ],
-    "no-class-assign": 2,
-    "no-confusing-arrow": [
-      2,
-      { "allowParens": true }
-    ],
-    "no-const-assign": 2,
-    "no-dupe-class-members": 2,
-    "no-duplicate-imports": 2,
-    "no-new-symbol": 2,
-    "no-this-before-super": 2,
-    "no-useless-computed-key": 2,
-    "no-useless-constructor": 2,
-    "no-useless-rename": [
-      2,
-      {
-        "ignoreDestructuring": false,
-        "ignoreImport": false,
-        "ignoreExport": false
-      }
-    ],
-    "no-var": 2,
-    "object-shorthand": [
-      2,
-      "always",
-      {
-        "ignoreConstructors": false,
-        "avoidQuotes": true
-      }
-    ],
-    "prefer-arrow-callback": [
-      2,
-      {
-        "allowNamedFunctions": false,
-        "allowUnboundThis": true
-      }
-    ],
-    "prefer-const": [
-      2,
-      {
-        "destructuring": "any",
-        "ignoreReadBeforeAssign": true
-      }
-    ],
-    "prefer-destructuring": [
-      2,
-      {
-        "VariableDeclarator": {
-          "array": false,
-          "object": true
-        },
-        "AssignmentExpression": {
-          "array": true,
-          "object": true
-        }
-      },
-      {
-        "enforceForRenamedProperties": false
-      }
-    ],
-    "prefer-numeric-literals": 2,
-    "prefer-rest-params": 2,
-    "prefer-spread": 2,
-    "prefer-template": 2,
-    "require-yield": 2,
-    "rest-spread-spacing": [
-      2,
-      "never"
-    ],
-    "symbol-description": 2,
-    "template-curly-spacing": 2,
-    "yield-star-spacing": [
-      2,
-      "after"
-    ],
-
-    "flowtype/space-after-type-colon": 0,
-
+    "jsx-a11y/click-events-have-key-events": 0,
+    "jsx-a11y/interactive-supports-focus": 0,
     "jsx-a11y/no-autofocus": 1,
     "jsx-a11y/no-onchange": 0,
     "jsx-a11y/no-static-element-interactions": 0,
-    "jsx-a11y/click-events-have-key-events": 0,
-    "jsx-a11y/interactive-supports-focus": 0,
 
-    "import/no-named-as-default": 0,
-    "import/no-unresolved": 0,
-
-    "react/button-has-type": 0,
-    "react/destructuring-assignment": 0,
-    "react/display-name": 0,
+    "react/button-has-type": 1,
+    "react/destructuring-assignment": 1,
+    "react/display-name": 2,
     "react/forbid-component-props": 0,
-    "react/forbid-elements": 0,
-    "react/forbid-foreign-prop-types": 0,
-    "react/forbid-prop-types": [
-      2,
-      { "forbid": ["any"] }
+    "react/forbid-elements": [
+      1,
+      {
+        "forbid": [
+          { "element": "button", "message": "Use <SharedButton> instead" },
+          { "element": "table", "message": "Use flexbox instead" }
+        ]
+      }
     ],
-    "react/jsx-handler-names": 0,
-    "react/jsx-closing-bracket-location": [
-      2,
-      "after-props"
-    ],
-    "react/jsx-curly-spacing": [
-      2,
-      { "when": "always" }
-    ],
-    "react/jsx-filename-extension": [
-      2,
-      { "extensions": [".js", ".jsx"] }
-    ],
-    "react/jsx-first-prop-new-line": [
-      2,
-      "never"
-    ],
-    "react/jsx-indent": [
-      2,
-      2
-    ],
-    "react/jsx-indent-props": 0,
+    "react/jsx-handler-names": 1,
+    "react/jsx-closing-bracket-location": [1, "line-aligned"],
+    "react/jsx-curly-spacing": 1,
+    "react/jsx-filename-extension": [2, { "extensions": [".js"] }],
+    "react/jsx-first-prop-new-line": 1,
+    "react/jsx-indent": [1, 2],
+    "react/jsx-indent-props": 1,
     "react/jsx-max-depth": 0,
-    "react/jsx-max-props-per-line": [
-      2,
-      { "maximum": 1, "when": "multiline" }
+    "react/jsx-max-props-per-line": [1, { "maximum": 1, "when": "multiline" }],
+    "react/jsx-no-bind": [
+      1,
+      {
+        "ignoreDOMComponents": true,
+        "ignoreRefs": true
+      }
     ],
-    "react/jsx-no-bind": 0,
     "react/jsx-no-literals": 0,
     "react/jsx-sort-props": 0,
+    "react/jsx-sort-default-props": 0,
     "react/no-array-index-key": 0,
-    "react/no-danger": 1,
+    "react/no-danger": 0,
     "react/no-set-state": 0,
-    "react/no-multi-comp": [
-      2,
-      { "ignoreStateless": true }
-    ],
-    "react/prefer-stateless-function": [
-      2,
-      { "ignorePureComponents": true }
-    ],
-    "react/require-optimization": 0,
+    "react/no-multi-comp": [1, { "ignoreStateless": true }],
+    "react/prefer-stateless-function": [1, { "ignorePureComponents": true }],
+    "react/require-optimization": 1,
     "react/sort-prop-types": 0
   }
 }


### PR DESCRIPTION
Grocery has its own `.eslintrc` because of its React-specific rules. This merges that into the generic `.eslintrc` hound is using so that all repos going forward can have a consistent JS linting style. 

According to Mike, grocery is the only project using JS right now so merging the two configs should be okay.

TODO:
- update `.eslintrc` with the merged file as well
- install overcommit