### PR TITLE
Ignore warnings for double quotes because of hound false positives

### DIFF
--- a/javascript/.eslintrc.json
+++ b/javascript/.eslintrc.json
@@ -20,7 +20,7 @@
     "no-multi-spaces": 1,
     "jsx-quotes": [1, "prefer-double"],
     "no-extra-semi": 1,
-    "quotes": [1, "double"],
+    "quotes": [0, "double"], // ignoring only on hound because of false positives due to fragments
     "semi": [1, "always"],
     "no-console": [2, { "allow": ["warn", "error"] }],
     "comma-dangle": 1,


### PR DESCRIPTION
Fragments cause hound to create false positives on the double quotes rule, so we should ignore it for hound but keep it on our local `.eslintrc` files