### PR TITLE
Disable JS on Hound

### DIFF
--- a/.hound.yml
+++ b/.hound.yml
@@ -7,7 +7,7 @@ credo:
   config_file: elixir/.credo.exs
 
 eslint:
-  enabled: true
+  enabled: false
   config_file: javascript/.eslintrc.json
 
 flake8:


### PR DESCRIPTION
https://app.asana.com/0/1200524927160045/1200588792879600/f

Disables hound for JS in favor of changes to https://github.com/hatchedlabs/grocery/pull/4603. 

The grocery-web repo hasn't been using Hound as well.